### PR TITLE
keep file cache in $XDG_RUNTIME_DIR if available

### DIFF
--- a/libbrowserid/bid_cache.c
+++ b/libbrowserid/bid_cache.c
@@ -571,8 +571,15 @@ _BIDAcquireCacheForUser(
              "file:%s/Library/Caches/com.padl.gss.BrowserID/%s.json",
              szPrefix, szTemplate);
 #else
-    snprintf(szFileName, sizeof(szFileName),
-             "file:/tmp/.%s.%d.json", szTemplate, geteuid());
+    char *szRunDir;
+
+    szRunDir = getenv("XDG_RUNTIME_DIR");
+    if (szRunDir != NULL)
+        snprintf(szFileName, sizeof(szFileName),
+                 "file:%s/%s.json", szRunDir, szTemplate);
+    else
+        snprintf(szFileName, sizeof(szFileName),
+                 "file:/tmp/.%s.%d.json", szTemplate, geteuid());
 #endif
 
     err = _BIDAcquireCache(context, szFileName, 0, pCache);


### PR DESCRIPTION
Various Linux distributions have started moving user-specific "runtime" data from /tmp to $XDG_RUNTIME_DIR (usually either /run/user/$USER or /run/user/$UID, created by PAM at login time). This avoids several security and/or privacy issues.
